### PR TITLE
Deploy to S3 Amazon Bucket using Gulp tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bower_components
 npm-debug.log
 build
+gulp/aws.js

--- a/README.md
+++ b/README.md
@@ -85,8 +85,38 @@ This solution was found [here](https://github.com/gulpjs/gulp/issues/217).
 > **gulp production**
 > Runs the default task using the production build
 
-> **gulp publish**
-> Pushes the contents of the *build* to the s3 bucket specified in the task file.
+> **gulp s3**
+> Pushes the contents of the *build* to the s3 bucket specified in the task file. You can either call s3:staging or s3:production.
+
+
+### Deploy
+
+In order to deploy you must first create *gulp/aws.js* file with the credentials for the Amazon S3 bucket, this file is already added to *.gitignore*
+so you don't compromise the keys by pushing them to the repository. The file needs to have this format: 
+
+```
+module.exports = {
+  "staging": {
+    "accessKeyId": "Amazon_s3_staging_access_key",
+    "secretAccessKey": "Amazon_s3_staging_secret_key",
+    "region": "Amazon_s3_staging_region",
+    "params": {
+    	"Bucket": "Amazon_s3_staging_bucket_name"
+	}
+  },
+  "production": {
+    "accessKeyId": "Amazon_s3_production_access_key",
+    "secretAccessKey": "Amazon_s3_production_secret_key",
+    "region": "Amazon_s3_production_region",
+    "params": {
+    	"Bucket": "Amazon_s3_production_bucket_name"
+	}
+  }
+};
+```
+Then you just run ```gulp build``` followed by the deploy task ```gulp s3:staging``` or ```gulp :s3:production```
+
+NOTE: You must have the corrects AIM permissions, if not, amazon will report an Access Denied error
 
 ## Contributing
 

--- a/gulp/tasks/s3.js
+++ b/gulp/tasks/s3.js
@@ -1,20 +1,11 @@
 var gulp = require('gulp'),
-    awspublish = require('gulp-awspublish');
+    awspublish = require('gulp-awspublish'),
+    awsKeys = require("../aws");
 
 var localConfig = {
-  buildSrc: './build',
-  stagingPublisher: awspublish.create({
-     "key": "...",
-     "secret": "...",
-     "bucket": "...",
-     "region": "..."
-  }),
-  productionPublisher: awspublish.create({
-     "key": "...",
-     "secret": "...",
-     "bucket": "...",
-     "region": "..."
-  }),
+  buildSrc: './build/**/*',
+  stagingPublisher: awspublish.create(awsKeys.staging),
+  productionPublisher: awspublish.create(awsKeys.production),
   stagingHeaders: {
 
   },
@@ -28,6 +19,7 @@ gulp.task('s3:staging', function() {
   return gulp.src(localConfig.buildSrc)
     .pipe(publisher.publish(localConfig.stagingHeaders))
     .pipe(publisher.cache())
+    .pipe(publisher.sync())
     .pipe(awspublish.reporter());
 });
 
@@ -36,5 +28,6 @@ gulp.task('s3:production', function() {
   return gulp.src(localConfig.buildSrc)
     .pipe(publisher.publish(localConfig.productionHeaders))
     .pipe(publisher.cache())
+    .pipe(publisher.sync())
     .pipe(awspublish.reporter());
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "del": "^1.1.1",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.2.0",
-    "gulp-awspublish": "^1.0.6",
+    "gulp-awspublish": "^2.0.0",
     "gulp-babel": "^5.1.0",
     "gulp-concat": "^2.5.2",
     "gulp-connect": "^2.2.0",


### PR DESCRIPTION
### Summary:
   <ul><li>Task for deploying to an Amazon S3 bucket using gulp-awspublish ( https://www.npmjs.com/package/gulp-awspublish) </li>
</ul>
