### PR TITLE
Changing Chrome with PhantomJS - Karma running on jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir -p /myapp && cp -a /tmp/node_modules /myapp
 
 ADD . /myapp
 WORKDIR /myapp
+
+RUN node_modules/.bin/bower install --allow-root

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ADD package.json /tmp/package.json
 RUN cd /tmp && npm install
 RUN mkdir -p /myapp && cp -a /tmp/node_modules /myapp
 
+ADD bower.json /tmp/bower.json
+RUN cd /tmp && node_modules/.bin/bower install --allow-root
+RUN cp -a /tmp/bower_components /myapp
+
 ADD . /myapp
 WORKDIR /myapp
-
-RUN node_modules/.bin/bower install --allow-root

--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "karma": "^0.13.9",
     "jasmine-core": "^2.3.4",
     "karma-jasmine": "^0.3.6",
-    "karma-chrome-launcher": "^0.2.0",
     "karma-ng-html2js-preprocessor": "^0.2.0",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "phantomjs": "^1.9.18",
     "gulp-sass-lint": "^1.1.0",
     "node-notifier": "^4.3.1"
   }

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -73,7 +73,14 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['PhantomJS'],
+
+
+    plugins: [
+        'karma-jasmine',
+        'karma-phantomjs-launcher',
+        'karma-ng-html2js-preprocessor'
+    ],
 
 
     // Continuous Integration mode

--- a/test/unit/specs/component1ControllerSpec.js
+++ b/test/unit/specs/component1ControllerSpec.js
@@ -2,7 +2,7 @@
 
 describe('Component 1', function () {
 
-  let component1Controller;
+  var component1Controller;
 
   beforeEach(function () {
     module('app');

--- a/test/unit/specs/component2ControllerSpec.js
+++ b/test/unit/specs/component2ControllerSpec.js
@@ -2,7 +2,7 @@
 
 describe('Component 2', function () {
 
-  let component2Controller;
+  var component2Controller;
 
   beforeEach(function () {
     module('app');


### PR DESCRIPTION
# Summary 

### Using PhantomJS
Instead of using Chrome, we can now run Karma with PhantomJS. As it is headless, it runs faster.

### Dockerfile
Also adding line in Dockerfile to run bower. With this, we'll have bower_components and we can configure Jenkins to run karma tests.