### PR TITLE
Adds robots txt gulp task

### DIFF
--- a/gulp/tasks/revisioning.js
+++ b/gulp/tasks/revisioning.js
@@ -11,13 +11,16 @@ const localConfig = {
 };
 
 var indexHtmlFilter = filter(['**/*', '!**/index.html'], { restore: true });
+var robotsTxtFilter = filter(['**/*', '!**/robots.txt'], { restore: true });
 
 gulp.task('revisioning', [], () => {
   return gulp.src(localConfig.src, { base: localConfig.base })
     .pipe(indexHtmlFilter)
+    .pipe(robotsTxtFilter)
     .pipe(rev())
     .pipe(revdel())
     .pipe(indexHtmlFilter.restore)
+    .pipe(robotsTxtFilter.restore)
     .pipe(revReplace())
     .pipe(gulp.dest(localConfig.dest))
     .pipe(rev.manifest())

--- a/gulp/tasks/robots.js
+++ b/gulp/tasks/robots.js
@@ -1,0 +1,12 @@
+import gulp from 'gulp';
+import runSequence from 'run-sequence';
+
+const localConfig = {
+  robotsFile: './src/robots.txt',
+  destFolder: './build/'
+};
+
+gulp.task('robots', () => {
+  return gulp.src(localConfig.robotsFile)
+    .pipe(gulp.dest(localConfig.destFolder));
+});


### PR DESCRIPTION
## Summary

- The repository was missing the robots.txt file to improve search engine robots
- I added the robots.txt empty file
- I added a gulp task that adds the robots.txt file to the build and doesn't add the cache hash to the end of the file.
